### PR TITLE
remove model

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
     constructor(map, options = {}) {
         super(options);
         this.map = map;
-        this.model = null;
         this.uiMarker = null;
         this.layer = new maptalks.VectorLayer('___layer___', {
             geometryEvents: false,
@@ -142,11 +141,7 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
         return this;
     }
 
-    enable() {
-        if (!this.model) {
-            console.warn('not find model data,please setModel(model)');
-            return this;
-        }
+    enable(coordinates) {
         if (this._enable) {
             return this;
         }
@@ -157,7 +152,7 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
         this.map.on(MOUSE_MOVE_EVENT, this._mouseMove, this);
         this.map.on(MOUSE_UP_EVENT, this._mouseUp, this);
         this.map.on(MOUSE_DOWN_EVENT, this._mouseDown, this);
-        this._createMarker();
+        this._createMarker(coordinates);
         this.layer.addTo(this.map);
         return this;
     }
@@ -186,45 +181,11 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
         return this._enable;
     }
 
-    setModel(model) {
-        if (model.getCoordinates && model.on) {
-            this.model = model;
-            this.disable();
-        } else {
-            console.error(model, 'is error ,only support Geometry');
-        }
-        return this;
-    }
-
-    getModel() {
-        return this.model;
-    }
-
-    getModelType() {
-        if (!this.model) {
-            return;
-        }
-        if (this.model.getObject3d) {
-            return 'threemodel';
-        }
-        if (this.model.setScales) {
-            return 'gltfmarekr';
-        }
-        if (this.model instanceof maptalks.Marker) {
-            return 'marker';
-        }
-        return 'others';
-    }
-
-    setTarget(model) {
-        return this.setModel(model);
-    }
-
-    _createMarker() {
+    _createMarker(coordinates) {
         if (this.uiMarker) {
             return this;
         }
-        const coordinate = this.model.getCoordinates();
+        const coordinate = coordinates;
         const height = coordinate.z || 0;
         this.height = height;
         const marker = new maptalks.ui.UIMarker(coordinate, {

--- a/index.js
+++ b/index.js
@@ -181,11 +181,10 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
         return this._enable;
     }
 
-    _createMarker(coordinates) {
+    _createMarker(coordinate) {
         if (this.uiMarker) {
             return this;
         }
-        const coordinate = coordinates;
         const height = coordinate.z || 0;
         this.height = height;
         const marker = new maptalks.ui.UIMarker(coordinate, {

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
     constructor(map, options = {}) {
         super(options);
         this.map = map;
+        this.model = null;
         this.uiMarker = null;
         this.layer = new maptalks.VectorLayer('___layer___', {
             geometryEvents: false,
@@ -142,6 +143,10 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
     }
 
     enable(coordinates) {
+        if (!coordinates && !this.model) {
+            console.warn('not find model data,please setModel(model)');
+            return this;
+        }
         if (this._enable) {
             return this;
         }
@@ -181,10 +186,45 @@ export class ModelControl extends maptalks.Eventable(maptalks.Class) {
         return this._enable;
     }
 
+    setModel(model) {
+        if (model.getCoordinates && model.on) {
+            this.model = model;
+            this.disable();
+        } else {
+            console.error(model, 'is error ,only support Geometry');
+        }
+        return this;
+    }
+
+    getModel() {
+        return this.model;
+    }
+
+    getModelType() {
+        if (!this.model) {
+            return;
+        }
+        if (this.model.getObject3d) {
+            return 'threemodel';
+        }
+        if (this.model.setScales) {
+            return 'gltfmarekr';
+        }
+        if (this.model instanceof maptalks.Marker) {
+            return 'marker';
+        }
+        return 'others';
+    }
+
+    setTarget(model) {
+        return this.setModel(model);
+    }
+
     _createMarker(coordinate) {
         if (this.uiMarker) {
             return this;
         }
+        coordinate = coordinate || this.model.getCoordinates();
         const height = coordinate.z || 0;
         this.height = height;
         const marker = new maptalks.ui.UIMarker(coordinate, {


### PR DESCRIPTION
ModelControl中model只是用来获取初始的coordinates，可以去掉ModelControl和model之间的关联，coordinates作为enable方法的参数传入，这样ModelControl能使用到更多的场景下，比如3dtiles，MultiGLTFMarker中某单个数据项等都能适用。